### PR TITLE
Add unit tests and fix method binding

### DIFF
--- a/src/application/config.py
+++ b/src/application/config.py
@@ -1,11 +1,13 @@
 # config.py
 from src.domain.services.rpc_functions import RpcFunctions
 
+# Instantiate RpcFunctions so that bound methods can be used in the table
+rpc_functions = RpcFunctions()
 
 METHOD_TABLE = {
-    "floor": RpcFunctions.floor,
-    "nroot": RpcFunctions.n_root,
-    "reverse": RpcFunctions.reverse,
-    "validAnagram": RpcFunctions.valid_anagram,
-    "sort": RpcFunctions.sort
+    "floor": rpc_functions.floor,
+    "nroot": rpc_functions.n_root,
+    "reverse": rpc_functions.reverse,
+    "validAnagram": rpc_functions.valid_anagram,
+    "sort": rpc_functions.sort,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Add the project root to sys.path to allow importing the src package
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_json_serializer.py
+++ b/tests/test_json_serializer.py
@@ -1,0 +1,10 @@
+from src.infrastructure.serializers.json_serializer import JsonSerializer
+
+
+def test_encode_decode_roundtrip():
+    serializer = JsonSerializer()
+    data = {"foo": "bar", "num": 123}
+    encoded = serializer.encode(data)
+    assert isinstance(encoded, bytes)
+    decoded = serializer.decode(encoded)
+    assert decoded == data

--- a/tests/test_rpc_functions.py
+++ b/tests/test_rpc_functions.py
@@ -1,0 +1,36 @@
+import pytest
+from src.domain.services.rpc_functions import RpcFunctions
+
+rpc = RpcFunctions()
+
+def test_floor():
+    assert rpc.floor(3.7) == 3
+    assert rpc.floor(-3.7) == -4
+
+def test_n_root_positive():
+    assert rpc.n_root(27, 3) == pytest.approx(3.0)
+
+
+def test_n_root_negative_odd():
+    assert rpc.n_root(-27, 3) == pytest.approx(-3.0)
+
+
+def test_n_root_invalid_n():
+    with pytest.raises(ValueError):
+        rpc.n_root(16, 0)
+
+
+def test_reverse():
+    assert rpc.reverse("abcdef") == "fedcba"
+
+
+def test_valid_anagram_true():
+    assert rpc.valid_anagram("anagram", "nagaram") is True
+
+
+def test_valid_anagram_false():
+    assert rpc.valid_anagram("rat", "car") is False
+
+
+def test_sort_strings():
+    assert rpc.sort(["banana", "apple", "cherry"]) == ["apple", "banana", "cherry"]

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -1,0 +1,35 @@
+from src.infrastructure.sockets.rpc_server import RpcServer
+from src.domain.entities.rpc_request import RpcRequest
+
+
+def create_server():
+    # Serializer and socket handler are not used in process_request
+    return RpcServer("/tmp/server", None, None)
+
+
+def test_process_request_floor():
+    server = create_server()
+    request = RpcRequest(method="floor", params=[3.7], id=1)
+    response = server.process_request(request)
+    assert response.results == "3"
+    assert response.result_type == "int"
+    assert response.error is None
+    assert response.id == 1
+
+
+def test_process_request_unknown_method():
+    server = create_server()
+    request = RpcRequest(method="foo", params=[], id=2)
+    response = server.process_request(request)
+    assert response.results is None
+    assert response.error.startswith("Unknown method")
+    assert response.id == 2
+
+
+def test_process_request_method_error():
+    server = create_server()
+    request = RpcRequest(method="nroot", params=[16, 0], id=3)
+    response = server.process_request(request)
+    assert response.results is None
+    assert "n must be positive" in response.error
+    assert response.id == 3


### PR DESCRIPTION
## Summary
- fix METHOD_TABLE to use bound RpcFunctions methods
- add tests for RpcFunctions, JsonSerializer, and RpcServer.process_request

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c26e472f188326833e52997fdd34b7